### PR TITLE
implementation of 'fcntl' locking backend

### DIFF
--- a/lib/IPC/ConcurrencyLimit.pm
+++ b/lib/IPC/ConcurrencyLimit.pm
@@ -228,6 +228,10 @@ Check whether the lock is still valid. If so,
 returns true. Otherwise, it releases (destroys) the lock
 and returns false.
 
+=head1 NOTES
+
+Consult documentation of each locking backend to learn their disadvantages
+
 =head1 AUTHOR
 
 Steffen Mueller, C<smueller@cpan.org>

--- a/lib/IPC/ConcurrencyLimit/WithStandby.pm
+++ b/lib/IPC/ConcurrencyLimit/WithStandby.pm
@@ -71,15 +71,16 @@ sub get_lock {
   my $interval = $self->{interval};
   eval {
     my $tries = 0;
-    do {{
+    while (1) {
       $id = $main_lock->get_lock;
       if (defined $id) {
         $st_lock->release_lock;
         last;
       }
-      ++$tries;
+
+      last unless $self->{retries}->(++$tries);
       sleep($interval) if $interval;
-    }} while (not defined($id) and $self->{retries}->($tries));
+    }
     1;
   }
   or do {


### PR DESCRIPTION
The idea behind introducing new backend was that default
'flock' backend has a disadvantage (or advantage) of survive
across forking. It's potentialy dangerous situation in some cases.
For instance, imagine that IPC::CL::Withstandby is used for building HA pair
of daemons, and daemon does forks after acquiring a lock. Now, if the
main process dies before any child, the standby daemon will fail to
promote itself to main one, because the lock is still held by all
children. The solution to this case would be to either explicitly close
lock file handler after forking, or use another locking mechanism which
is free of this feature.

However, fcntl behaivour is very nasty. So, you should be really
carefull in using it. 

Honestly say, after implementing the idea of using fcntl I'm not sure that is was a good one. Simply say, the logic of fcntl locking is very broken. Here is the article which describe all the issue with fcntl (and flock as well) http://0pointer.de/blog/projects/locking.html. Btw, due to that issues fcntl backend failed to pass any test.

I've decided to make a pull request instead of directly pushing (thanks for the access) because I don't have strong opinion on whether we need to provide alternative choice or not. Probably not. If you have any concerns feel free to reject it.
