### PR TITLE
Count *down*  when we try to acquire a lock

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl extension IPC::ConcurrencyLimit
 
+0.12  2015-09-18
+  - Flock:
+    - start at the *highest* id, and count *down*
+      to find the lock we want to use.
+    - add file_prefix option
+    - add file_ext option
+
+
 0.11  Tue Aug 20 21:42 2013
   - Fix incorrect documentation for retries parameter
 

--- a/lib/IPC/ConcurrencyLimit.pm
+++ b/lib/IPC/ConcurrencyLimit.pm
@@ -3,7 +3,7 @@ use 5.008001;
 use strict;
 use warnings;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 use Carp qw(croak);
 


### PR DESCRIPTION
This encourages new processors which have started with a higher number
of allowed locks to not compete (as much) with existing processors that
were started with a lower number of allowed locks.

Also added "file_prefix" and "file_ext" options to allow finer control
over the lock file names.